### PR TITLE
Faster ColorSelection

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "redux-undo": "^1.0.1",
     "resize-observer-polyfill": "^1.5.1",
     "three": "^0.124.0",
+    "ts-priority-queue": "^0.1.1",
     "typescript": "^4.1.3",
     "underscore": "^1.12.0",
     "use-constant": "^1.1.0",

--- a/src/image/flood.ts
+++ b/src/image/flood.ts
@@ -98,7 +98,7 @@ export const makeFloodMap = ({
   });
 };
 
-// Generate a tolerance map and associate it with the image itself
+// Expand a watershed map until the desired tolerance is reached.
 export const doFlood = ({
   floodMap,
   toleranceMap,

--- a/src/image/flood.ts
+++ b/src/image/flood.ts
@@ -1,4 +1,12 @@
 import * as ImageJS from "image-js";
+import PriorityQueue from "ts-priority-queue";
+
+const dirs = [
+  [1, 0],
+  [0, 1],
+  [-1, 0],
+  [0, -1],
+];
 
 class Position {
   x: number;
@@ -77,7 +85,7 @@ export const makeFloodMap = ({
       tol.push(Math.floor((red + green + blue) / 3));
     }
   } else if (image.data.length === image.width * image.height) {
-    //gresycale
+    //greyscale
     for (let i = 0; i < image.data.length; i++) {
       const grey = Math.abs(image.data[i] - color[0]);
       tol.push(Math.floor((grey / image.maxValue) * 255));
@@ -88,4 +96,42 @@ export const makeFloodMap = ({
     alpha: 0,
     components: 1,
   });
+};
+
+// Generate a tolerance map and associate it with the image itself
+export const doFlood = ({
+  floodMap,
+  toleranceMap,
+  queue,
+  tolerance,
+  maxTol,
+  seen,
+}: {
+  floodMap: ImageJS.Image;
+  toleranceMap: ImageJS.Image;
+  queue: PriorityQueue<Array<number>>;
+  tolerance: number;
+  maxTol: number;
+  seen: Set<number>;
+}) => {
+  while (queue.length > 0 && queue.peek()[2] <= tolerance) {
+    let currentPoint = queue.dequeue();
+    maxTol = Math.max(currentPoint[2], maxTol);
+    floodMap.setPixelXY(currentPoint[0], currentPoint[1], [maxTol]);
+    for (let dir of dirs) {
+      let newX = currentPoint[0] + dir[0];
+      let newY = currentPoint[1] + dir[1];
+      let idx = newX + newY * toleranceMap.width;
+      if (
+        !seen.has(idx) &&
+        newX >= 0 &&
+        newY >= 0 &&
+        newX < toleranceMap.width &&
+        newY < toleranceMap.height
+      ) {
+        queue.queue([newX, newY, toleranceMap.getPixelXY(newX, newY)[0]]);
+        seen.add(idx);
+      }
+    }
+  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -15467,6 +15467,11 @@ ts-pnp@1.2.0, ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+ts-priority-queue@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ts-priority-queue/-/ts-priority-queue-0.1.1.tgz#557be9c76e4b86c0da3c0a17911543805a899fa6"
+  integrity sha512-jNwbk4ItfTHVopnlQ/Z7UUlbF1TNsdXS2cb1W8kI6lm8UauIjs8CYSOEh1E/yrIEhl+HVFUMp60ma6fKuvBhBQ==
+
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"


### PR DESCRIPTION
Taking some lessons from the Magnetic tool, I've tried to adapt the ColorSelection tool to avoid needing to re-run the entire watershed algorithm each frame. I've made it so that the watershed PriorityQueue is stored and resumed as the user increases the tolerance setting (mouse drag). In practice this stops it chugging so much when working with high tolerance values. This would also make it easier to offload the work onto a worker thread if we ever feel like it.

Currently it's a bit slower when working with really small tolerance values, because I can't get Image-JS's ROI manager to directly create a mask via thresholding. I also can't get it to just make a single ROI, so currently it has to make the mask, make an ROI Manager and then make the proper ROI from the mask. If someone could help clean that up I'd appreciate it.