### PR TITLE
Use a dictionary to store superpixel point lists

### DIFF
--- a/src/image/Tool/AnnotationTool/QuickAnnotationTool/QuickAnnotationTool.ts
+++ b/src/image/Tool/AnnotationTool/QuickAnnotationTool/QuickAnnotationTool.ts
@@ -9,6 +9,7 @@ export class QuickAnnotationTool extends AnnotationTool {
   currentSuperpixels: Set<number> = new Set<number>();
   lastSuperpixel: number = 0;
   superpixels?: Int32Array;
+  superpixelsMap?: { [key: number]: Array<number> };
   currentMask?: ImageJS.Image;
   map?: Uint8Array | Uint8ClampedArray;
 
@@ -81,10 +82,8 @@ export class QuickAnnotationTool extends AnnotationTool {
 
     this.currentSuperpixels.add(superpixel);
 
-    this.superpixels.forEach((pixel: number, index: number) => {
-      if (pixel === superpixel) {
-        this.currentMask!.setPixel(index, [255, 0, 0, 150]);
-      }
+    this.superpixelsMap![superpixel].forEach((index: number) => {
+      this.currentMask!.setPixel(index, [255, 0, 0, 150]);
     });
   }
 
@@ -125,6 +124,15 @@ export class QuickAnnotationTool extends AnnotationTool {
     instance.map = map;
 
     instance.superpixels = superpixels;
+
+    instance.superpixelsMap = {};
+
+    superpixels.forEach((pixel: number, index: number) => {
+      if (!(pixel in instance.superpixelsMap!)) {
+        instance.superpixelsMap![pixel] = [];
+      }
+      instance.superpixelsMap![pixel].push(index);
+    });
 
     return instance;
   }


### PR DESCRIPTION
I think I have this working. Herein we generate a dictionary mapping superpixel IDs to a list of points, so that we can avoid needing to scan the entire original image each time we want to draw a new image.

On my end the performance difference isn't huge (we save about 20ms per draw on mid-sized images), I think there's a bigger slowdown somewhere which would need our attention.

I couldn't remove the need to store the superpixel image as well, since we need to fetch a pixel's ID from it. If someone has a means for us to efficiently fetch the pixel value under the mouse cursor from the dictionary then I'd be keen to hear it.