### PR TITLE
Tweak data url generation parameters

### DIFF
--- a/src/components/ImageViewer/Content/Stage/Selection/QuickSelection/QuickSelection.tsx
+++ b/src/components/ImageViewer/Content/Stage/Selection/QuickSelection/QuickSelection.tsx
@@ -15,7 +15,9 @@ export const QuickSelection = ({ operator }: QuickSelectionProps) => {
     if (!operator.currentMask) return;
 
     const image = new Image();
-    image.src = operator.currentMask.toDataURL();
+    image.src = operator.currentMask.toDataURL("image-png", {
+      useCanvas: true,
+    });
     setImage(image);
   }, [operator.currentMask, operator.lastSuperpixel]);
 

--- a/src/image/Tool/AnnotationTool/ColorAnnotationTool/ColorAnnotationTool.ts
+++ b/src/image/Tool/AnnotationTool/ColorAnnotationTool/ColorAnnotationTool.ts
@@ -199,7 +199,7 @@ export class ColorAnnotationTool extends AnnotationTool {
     // Set the origin point to white, for visibility.
     overlay.setPixelXY(position.x, position.y, [255, 255, 255, 255]);
 
-    return overlay.toDataURL();
+    return overlay.toDataURL("image-png", { useCanvas: true });
   }
 
   private updateOverlay(position: { x: number; y: number }) {


### PR DESCRIPTION
Was playing around trying to figure out why some tools feel sluggish. For quickselection it's largely coming from the conversion of the mask into a data URL. I tried out a few of the parameters on that method, and in my hands using this version gives about a 4x speed boost which is most noticable when moving the mouse around. Probably worth checking on other platforms. I'm also keen to see whether this would play well with #199.

Also saw a mild benefit on colorselection, so I've changed that call too.