### PR TITLE
Further ColorSelection optimisation

### DIFF
--- a/src/image/Tool/AnnotationTool/ColorAnnotationTool/ColorAnnotationTool.ts
+++ b/src/image/Tool/AnnotationTool/ColorAnnotationTool/ColorAnnotationTool.ts
@@ -10,7 +10,7 @@ export class ColorAnnotationTool extends AnnotationTool {
   roiContour?: ImageJS.Image;
   roiMask?: ImageJS.Image;
   roiManager?: ImageJS.RoiManager;
-  offset?: { x: number; y: number } = { x: 0, y: 0 };
+  offset: { x: number; y: number } = { x: 0, y: 0 };
   overlayData: string = "";
   points: Array<number> = [];
   initialPosition: { x: number; y: number } = { x: 0, y: 0 };
@@ -226,7 +226,7 @@ export class ColorAnnotationTool extends AnnotationTool {
 
     this.overlayData = ColorAnnotationTool.colorOverlay(
       this.roiMask,
-      this.offset!,
+      this.offset,
       position,
       this.image.width,
       this.image.height,


### PR DESCRIPTION
@alicelucas has found that on large images slow performance is in part due to the need to generate an ROI from each mask. While the ROI produces a smaller mask of just the area we want to show, the process of converting a whole image mask to an ROI is rather slow on a large image.

To resolve this, we now pass the entire mask into the overlay image generator and keep offset at 0,0. I expect the offset parameter can probably be removed entirely. An ROI is still needed to generate contours, so converting the mask into an ROI is now performed on mouse up.

Should partially resolve #216. The watershed map generation is still expensive when using large tolerance values on large images, but refresh rate should be faster.