### PR TITLE
Add canvas edge buffer zone

### DIFF
--- a/src/components/ImageViewer/Content/Stage/Stage/Stage.tsx
+++ b/src/components/ImageViewer/Content/Stage/Stage/Stage.tsx
@@ -523,6 +523,24 @@ export const Stage = () => {
 
       if (toolType === ToolType.PenAnnotation) setCurrentPosition(relative);
 
+      // Add a little leeway around the canvas to aid drawing up to the edges
+      if (relative.x > -50 && relative.x < 0) {
+        relative.x = 0;
+      } else if (
+        relative.x > scaledImageWidth &&
+        relative.x < scaledImageWidth + 50
+      ) {
+        relative.x = scaledImageWidth;
+      }
+      if (relative.y > -50 && relative.y < 0) {
+        relative.y = 0;
+      } else if (
+        relative.y > scaledImageHeight &&
+        relative.y < scaledImageHeight + 50
+      ) {
+        relative.y = scaledImageHeight;
+      }
+
       if (
         relative.x > scaledImageWidth ||
         relative.y > scaledImageHeight ||


### PR DESCRIPTION
Fixes #195

In this PR we treat mouse positions slightly off the edge of the canvas as being on the very edge of the canvas. In practice this makes it easier to draw selectors right up to the image border.

Went with a 50px radius around the image, but this can be adjusted if we want.
