### PR TITLE
Improve annotation "Confirm" button, add "Clear" button

### DIFF
--- a/src/components/ImageViewer/Content/Stage/Stage/Stage.tsx
+++ b/src/components/ImageViewer/Content/Stage/Stage/Stage.tsx
@@ -73,7 +73,6 @@ import { usePointer } from "../../../../../hooks/usePointer/usePointer";
 import { pointerSelectionSelector } from "../../../../../store/selectors/pointerSelectionSelector";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { saveAnnotationButtonClickSelector } from "../../../../../store/selectors/saveAnnotationButtonClickSelector";
 
 export const Stage = () => {
   const imageRef = useRef<Konva.Image>(null);
@@ -93,15 +92,12 @@ export const Stage = () => {
   const unselectedAnnotations = useSelector(unselectedAnnotationsSelector);
   const selectionMode = useSelector(selectionModeSelector);
 
-  const saveAnnotationButtonClick = useSelector(
-    saveAnnotationButtonClickSelector
-  );
-
   const stageHeight = useSelector(stageHeightSelector);
   const stageWidth = useSelector(stageWidthSelector);
   const stagePosition = useSelector(stagePositionSelector);
 
   const saveLabelRef = useRef<Konva.Label>();
+  const clearLabelRef = useRef<Konva.Label>();
 
   const [currentPosition, setCurrentPosition] = useState<{
     x: number;
@@ -430,8 +426,12 @@ export const Stage = () => {
 
       layer.batchDraw();
 
-      const label = stageRef.current.findOne(`#label`);
-      if (label) saveLabelRef.current = label as Konva.Label;
+      // Not ideal but this figures out which label is which
+      const label = stageRef.current.find(`#label`);
+      if (label.length > 1) {
+        saveLabelRef.current = label[0] as Konva.Label;
+        clearLabelRef.current = label[1] as Konva.Label;
+      }
     });
   }, [selectedAnnotationsIds, selectedAnnotation?.contour]);
 
@@ -481,16 +481,23 @@ export const Stage = () => {
       if (
         saveLabelRef &&
         saveLabelRef.current &&
-        saveLabelRef.current.getText()
+        saveLabelRef.current.getText() &&
+        clearLabelRef.current
       ) {
         //do not proceed with mouse down events if user has clicked on Save Annotation button
         if (
-          relative.x <
+          (relative.x <
             saveLabelRef.current.x() + saveLabelRef.current.width() &&
-          relative.x > saveLabelRef.current.x() &&
-          relative.y <
-            saveLabelRef.current.y() + saveLabelRef.current.height() &&
-          relative.y > saveLabelRef.current.y()
+            relative.x > saveLabelRef.current.x() &&
+            relative.y <
+              saveLabelRef.current.y() + saveLabelRef.current.height() &&
+            relative.y > saveLabelRef.current.y()) ||
+          (relative.x <
+            clearLabelRef.current.x() + clearLabelRef.current.width() &&
+            relative.x > clearLabelRef.current.x() &&
+            relative.y <
+              clearLabelRef.current.y() + clearLabelRef.current.height() &&
+            relative.y > clearLabelRef.current.y())
         ) {
           return;
         }
@@ -681,10 +688,6 @@ export const Stage = () => {
     deselectAllAnnotations();
     deselectAllTransformers();
   };
-
-  useEffect(() => {
-    confirmAnnotations();
-  }, [saveAnnotationButtonClick]);
 
   useHotkeys(
     "enter",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -23,7 +23,6 @@ export {
   setPointerSelection,
   setQuickSelectionBrushSize,
   setSaturation,
-  setSaveAnnotationButtonClick,
   setSelectedAnnotation,
   setSelectedAnnotations,
   setSelectionMode,

--- a/src/store/selectors/saveAnnotationButtonClickSelector.ts
+++ b/src/store/selectors/saveAnnotationButtonClickSelector.ts
@@ -1,9 +1,0 @@
-import { HistoryStateType } from "../../types/HistoryStateType";
-
-export const saveAnnotationButtonClickSelector = ({
-  state,
-}: {
-  state: HistoryStateType;
-}) => {
-  return state.present.saveAnnotationButtonClick;
-};

--- a/src/store/slices/applicationSlice.ts
+++ b/src/store/slices/applicationSlice.ts
@@ -67,7 +67,6 @@ const initialState: StateType = {
   },
   quickSelectionBrushSize: 40,
   saturation: 0,
-  saveAnnotationButtonClick: false,
   selectedAnnotation: undefined,
   selectedAnnotations: [],
   selectedCategory: "00000000-0000-0000-0000-000000000000",
@@ -307,13 +306,6 @@ export const applicationSlice = createSlice({
     ) {
       state.saturation = action.payload.saturation;
     },
-    setSaveAnnotationButtonClick(
-      state: StateType,
-      action: PayloadAction<{ saveAnnotationButtonClick: boolean }>
-    ) {
-      state.saveAnnotationButtonClick =
-        action.payload.saveAnnotationButtonClick;
-    },
     setSeletedCategory(
       state: StateType,
       action: PayloadAction<{ selectedCategory: string }>
@@ -420,7 +412,6 @@ export const {
   setPointerSelection,
   setQuickSelectionBrushSize,
   setSaturation,
-  setSaveAnnotationButtonClick,
   setSelectedAnnotation,
   setSelectedAnnotations,
   setSelectionMode,

--- a/src/store/slices/index.ts
+++ b/src/store/slices/index.ts
@@ -24,7 +24,6 @@ export {
   setPointerSelection,
   setQuickSelectionBrushSize,
   setSaturation,
-  setSaveAnnotationButtonClick,
   setSelectedAnnotation,
   setSelectedAnnotations,
   setSelectionMode,

--- a/src/types/StateType.ts
+++ b/src/types/StateType.ts
@@ -29,7 +29,6 @@ export type StateType = {
   };
   quickSelectionBrushSize: number;
   saturation: number;
-  saveAnnotationButtonClick: boolean;
   selectedAnnotations: Array<AnnotationType>;
   selectedAnnotation: AnnotationType | undefined;
   selectedCategory: string;


### PR DESCRIPTION
Replaces the boolean flag with a dispatch-based implementation. Adds a 'clear' button to cancel annotating.

![image](https://user-images.githubusercontent.com/26802537/117866350-07f6fc00-b265-11eb-827c-67be8855d5d8.png)


One thing that needs more work is how pointer/modify annotation mode is handled. Currently (and in the existing version in the master branch) the buttons get confused if the annotation is resized so that the box is on top of where the annotation previously was. I think that clicking then both re-selects the annotation and executes the update command, making the size changes revert.

Also need to figure out what we want the 'clear' button to do when modifying an existing annotation.