### PR TITLE
Use konva filters for image rescaling

### DIFF
--- a/src/components/ImageViewer/Content/Stage/Image/Image.tsx
+++ b/src/components/ImageViewer/Content/Stage/Image/Image.tsx
@@ -3,14 +3,12 @@ import React, { useEffect, useState } from "react";
 import useImage from "use-image";
 import Konva from "konva";
 import { useSelector } from "react-redux";
-import {
-  boundingClientRectSelector,
-  toolTypeSelector,
-} from "../../../../../store/selectors";
+import { boundingClientRectSelector } from "../../../../../store/selectors";
 import { scaledImageWidthSelector } from "../../../../../store/selectors/scaledImageWidthSelector";
 import { scaledImageHeightSelector } from "../../../../../store/selectors/scaledImageHeightSelector";
 import { imageSrcSelector } from "../../../../../store/selectors/imageSrcSelector";
-import { ToolType } from "../../../../../types/ToolType";
+import { channelsSelector } from "../../../../../store/selectors/intensityRangeSelector";
+import { createIntensityFilter } from "../../../ToolOptions/ColorAdjustmentOptions/ColorAdjustmentOptions/ColorAdjustmentOptions";
 
 export const Image = React.forwardRef<Konva.Image>((_, ref) => {
   const src = useSelector(imageSrcSelector);
@@ -23,7 +21,16 @@ export const Image = React.forwardRef<Konva.Image>((_, ref) => {
 
   const [cachedImage, setCachedImage] = useState<HTMLImageElement>();
 
+  const [filters, setFilters] = useState<Array<any>>();
+
+  const channels = useSelector(channelsSelector);
+
   const boundingClientRect = useSelector(boundingClientRectSelector);
+
+  useEffect(() => {
+    const IntensityFilter = createIntensityFilter(channels);
+    setFilters([IntensityFilter]);
+  }, [channels]);
 
   useEffect(() => {
     if (image) {
@@ -51,6 +58,7 @@ export const Image = React.forwardRef<Konva.Image>((_, ref) => {
       image={cachedImage}
       ref={ref}
       width={width}
+      filters={filters}
     />
   );
 });

--- a/src/components/ImageViewer/Content/Stage/Stage/Stage.tsx
+++ b/src/components/ImageViewer/Content/Stage/Stage/Stage.tsx
@@ -96,7 +96,7 @@ export const Stage = () => {
   const saveLabelRef = useRef<Konva.Label>();
   const clearLabelRef = useRef<Konva.Label>();
 
-  const [foo, setFoo] = useState<boolean>(false);
+  const [imageCached, setImageCached] = useState<boolean>(false);
 
   const [currentPosition, setCurrentPosition] = useState<{
     x: number;
@@ -755,13 +755,14 @@ export const Stage = () => {
   }, [annotations?.length]);
 
   useEffect(() => {
-    console.error("BIG OBVIOUS TEXT STRING In There");
+    setImageCached(false);
+    imageRef.current?.clearCache();
+  }, [src]);
+
+  useEffect(() => {
     if (!imageRef.current) return;
-    imageRef.current.clearCache();
-    console.info("In There", imageRef.current.width());
-    imageRef.current.filters([Konva.Filters.Invert]);
-    if (foo) imageRef.current.cache();
-    setFoo(true);
+    if (imageCached) imageRef.current.cache();
+    setImageCached(true);
   }, [channels]);
 
   const [tool, setTool] = useState<Tool>();
@@ -775,9 +776,6 @@ export const Stage = () => {
   const { draggable } = useHandTool();
 
   const KonvaImage = <Image ref={imageRef} />;
-
-  // imageRef.current?.cache();
-  // console.info("Caching here");
 
   return (
     <ReactReduxContext.Consumer>

--- a/src/components/ImageViewer/Content/Stage/Stage/Stage.tsx
+++ b/src/components/ImageViewer/Content/Stage/Stage/Stage.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { ToolType } from "../../../../../types/ToolType";
 import {
   imageInstancesSelector,
+  imageOriginalSrcSelector,
   invertModeSelector,
   selectedCategorySelector,
   selectionModeSelector,
@@ -64,10 +65,13 @@ import { usePointer } from "../../../../../hooks/usePointer/usePointer";
 import { pointerSelectionSelector } from "../../../../../store/selectors/pointerSelectionSelector";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
+import { channelsSelector } from "../../../../../store/selectors/intensityRangeSelector";
 
 export const Stage = () => {
-  const imageRef = useRef<Konva.Image>(null);
+  const imageRef = useRef<Konva.Image | null>(null);
   const stageRef = useRef<Konva.Stage>(null);
+
+  const src = useSelector(imageOriginalSrcSelector);
 
   const selectingRef = useRef<Konva.Line | null>(null);
 
@@ -79,6 +83,8 @@ export const Stage = () => {
   const quickSelectionBrushSize = useSelector(quickSelectionBrushSizeSelector);
   const selectedCategory = useSelector(selectedCategorySelector);
 
+  const channels = useSelector(channelsSelector);
+
   const selectedAnnotations = useSelector(selectedAnnotationsSelector);
   const unselectedAnnotations = useSelector(unselectedAnnotationsSelector);
   const selectionMode = useSelector(selectionModeSelector);
@@ -89,6 +95,8 @@ export const Stage = () => {
 
   const saveLabelRef = useRef<Konva.Label>();
   const clearLabelRef = useRef<Konva.Label>();
+
+  const [foo, setFoo] = useState<boolean>(false);
 
   const [currentPosition, setCurrentPosition] = useState<{
     x: number;
@@ -746,6 +754,16 @@ export const Stage = () => {
     deselectAllAnnotations();
   }, [annotations?.length]);
 
+  useEffect(() => {
+    console.error("BIG OBVIOUS TEXT STRING In There");
+    if (!imageRef.current) return;
+    imageRef.current.clearCache();
+    console.info("In There", imageRef.current.width());
+    imageRef.current.filters([Konva.Filters.Invert]);
+    if (foo) imageRef.current.cache();
+    setFoo(true);
+  }, [channels]);
+
   const [tool, setTool] = useState<Tool>();
 
   useEffect(() => {
@@ -755,6 +773,11 @@ export const Stage = () => {
   useKeyboardShortcuts();
 
   const { draggable } = useHandTool();
+
+  const KonvaImage = <Image ref={imageRef} />;
+
+  // imageRef.current?.cache();
+  // console.info("Caching here");
 
   return (
     <ReactReduxContext.Consumer>
@@ -773,7 +796,7 @@ export const Stage = () => {
           <Provider store={store}>
             <DndProvider backend={HTML5Backend}>
               <Layer>
-                <Image ref={imageRef} />
+                {KonvaImage}
 
                 <ZoomSelection />
 

--- a/src/components/ImageViewer/ToolOptions/ColorAdjustmentOptions/ColorAdjustmentOptions/ColorAdjustmentOptions.tsx
+++ b/src/components/ImageViewer/ToolOptions/ColorAdjustmentOptions/ColorAdjustmentOptions/ColorAdjustmentOptions.tsx
@@ -8,7 +8,6 @@ import ListItemText from "@material-ui/core/ListItemText";
 import { useDispatch, useSelector } from "react-redux";
 import { applicationSlice } from "../../../../../store";
 import { imageOriginalSrcSelector } from "../../../../../store/selectors";
-import * as ImageJS from "image-js";
 import { ChannelsList } from "../ChannelsList";
 import { channelsSelector } from "../../../../../store/selectors/intensityRangeSelector";
 import { ChannelType } from "../../../../../types/ChannelType";
@@ -87,6 +86,31 @@ const HueAndSaturationList = () => {
   );
 };
 
+export function createIntensityFilter(channels: ChannelType[]) {
+  return function (imageData: { data: any }) {
+    let data = imageData.data;
+    const scaleIntensity = (channel: ChannelType, pixel: number) => {
+      if (!channel.visible) return 0;
+      if (pixel < channel.range[0]) return 0;
+      if (pixel >= channel.range[1]) return 255;
+      return (
+        255 *
+        ((pixel - channel.range[0]) / (channel.range[1] - channel.range[0]))
+      );
+    };
+
+    for (let i = 0; i < data.length; i += 4) {
+      // red
+      data[i] = scaleIntensity(channels[0], data[i]);
+      // green
+      data[i + 1] = scaleIntensity(channels[1], data[i + 1]);
+      // blue
+      data[i + 2] = scaleIntensity(channels[2], data[i + 2]);
+    }
+    return data;
+  };
+}
+
 export const ColorAdjustmentOptions = () => {
   const t = useTranslation();
 
@@ -97,12 +121,6 @@ export const ColorAdjustmentOptions = () => {
   const imageShape = useSelector(imageShapeSelector);
 
   const channels = useSelector(channelsSelector);
-
-  const [prevChannels, setPrevChannels] = useState<Array<ChannelType>>([]); //used to keep track of which channel was changed
-
-  const [image, setImage] = useState<ImageJS.Image>();
-
-  const [origImage, setOrigImage] = useState<ImageJS.Image>();
 
   const [displayedValues, setDisplayedValues] = useState<Array<Array<number>>>(
     channels.map((channel: ChannelType) => [...channel.range])
@@ -126,81 +144,15 @@ export const ColorAdjustmentOptions = () => {
 
     const defaultChannels = setDefaultChannels(imageShape.channels);
 
-    ImageJS.Image.load(originalSrc).then((imageIn) => {
-      setOrigImage(imageIn);
-
-      const newImage = ImageJS.Image.createFrom(imageIn, {
-        data: Uint8Array.from(imageIn.data),
-      });
-      setImage(newImage);
-    });
     dispatch(
       applicationSlice.actions.setChannels({
         channels: defaultChannels,
       })
     );
-    setPrevChannels(defaultChannels);
     setDisplayedValues(
       defaultChannels.map((channel: ChannelType) => [...channel.range])
     );
   }, [originalSrc]);
-
-  useEffect(() => {
-    if (!origImage || !image) return;
-    const changedChannel = changedChannelIndex();
-    if (changedChannel === undefined || changedChannel === -1) return;
-    applyScaling(changedChannel);
-    setPrevChannels(channels);
-  }, [channels]);
-
-  /*
-   * Find out the channel index that was changed by the slider to avoid rescaling al channels
-   * */
-  const changedChannelIndex = () => {
-    const visibles = channels.map((channel: ChannelType) => channel.visible);
-    const ranges = channels.map((channel: ChannelType) => channel.range);
-    const changedChannels = prevChannels.map(
-      (prevChannel: ChannelType, idx: number) => {
-        if (
-          prevChannel.range[0] !== ranges[idx][0] ||
-          prevChannel.range[1] !== ranges[idx][1] ||
-          prevChannel.visible !== visibles[idx]
-        ) {
-          return idx;
-        } else return -1;
-      }
-    );
-    return changedChannels.find((index: number) => {
-      return index !== -1;
-    });
-  };
-
-  const scaleIntensity = (range: Array<number>, pixel: number) => {
-    if (pixel < range[0]) return 0;
-    if (pixel >= range[1]) return 255;
-    return 255 * ((pixel - range[0]) / (range[1] - range[0]));
-  };
-
-  const applyScaling = (channelIndex: number) => {
-    const channelTgt = channels[channelIndex];
-    // @ts-ignore
-    const rawData = origImage.getChannel(channelIndex);
-    if (!channelTgt.visible) {
-      rawData.data = new Uint8Array(rawData.data.length);
-    } else {
-      for (let i = 0; i < rawData.data.length; i++) {
-        let pix = rawData.data[i];
-        rawData.setPixel(i, [scaleIntensity(channelTgt.range, pix)]);
-      }
-    }
-    // @ts-ignore
-    image.setChannel(channelIndex, rawData);
-    dispatch(
-      applicationSlice.actions.setImageSrc({
-        src: image!.toDataURL("image/png", { useCanvas: true }),
-      })
-    );
-  };
 
   const onResetChannelsClick = () => {
     if (!imageShape) return;
@@ -210,12 +162,6 @@ export const ColorAdjustmentOptions = () => {
         channels: defaultChannels,
       })
     );
-    setImage(
-      ImageJS.Image.createFrom(origImage!, {
-        data: Uint8Array.from(origImage!.data),
-      })
-    );
-    setPrevChannels(channels);
     setDisplayedValues(
       defaultChannels.map((channel: ChannelType) => [...channel.range])
     );


### PR DESCRIPTION
I think I have this mostly working. Adjusting channels now generates a custom konva filter which performs the rescaling operation on the raw data without the need to generate a data url and re-render the entire canvas from scratch.

Things that could use tidying up:
- Greyscale images should have 1 slider for channels. Konva will always consider an image as RGB, but we can just make 1 slider that modifies all channels.
- Switching images is less tidy than I'd like, sometimes it needs an extra re-render to fully update.
- Some code duplication in ColorAdjustmentOptions between the reset button and the new image detection function.
- Not sure how this will play with being able to modify what data is exposed to the tools (esp. disabling channels).

In my hands this approach is much faster, we seem to get an image update in <50ms even when using the Malaria example, and despite it rescaling all channels each time. I think it's promising.