### PR TITLE
Add option to export annotations as label matrix

### DIFF
--- a/src/components/ImageViewer/CategoriesList/SaveMenu/ExportAnnotationsAsMatrixMenuItem.tsx
+++ b/src/components/ImageViewer/CategoriesList/SaveMenu/ExportAnnotationsAsMatrixMenuItem.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { MenuItem } from "@material-ui/core";
+import ListItemText from "@material-ui/core/ListItemText";
+import { useSelector } from "react-redux";
+import {
+  categoriesSelector,
+  imageInstancesSelector,
+} from "../../../../store/selectors";
+import { imagesSelector } from "../../../../store/selectors/imagesSelector";
+import JSZip from "jszip";
+import { saveAs } from "file-saver";
+import { saveAnnotationsAsMatrix } from "../../../../image/imageHelper";
+
+type SaveAnnotationsMenuItemProps = {
+  popupState: any;
+};
+
+export const ExportAnnotationsAsMatrixMenuItem = ({
+  popupState,
+}: SaveAnnotationsMenuItemProps) => {
+  const annotations = useSelector(imageInstancesSelector);
+  const images = useSelector(imagesSelector);
+  const categories = useSelector(categoriesSelector);
+
+  const onExport = () => {
+    popupState.close();
+
+    if (!annotations) return;
+
+    let zip = new JSZip();
+
+    Promise.all(saveAnnotationsAsMatrix(images, categories, zip)).then(() => {
+      zip.generateAsync({ type: "blob" }).then((blob) => {
+        saveAs(blob, "labels.zip");
+      });
+    });
+  };
+
+  return (
+    <MenuItem onClick={onExport}>
+      <ListItemText primary="Export label matrices" />
+    </MenuItem>
+  );
+};

--- a/src/components/ImageViewer/CategoriesList/SaveMenu/SaveMenu.tsx
+++ b/src/components/ImageViewer/CategoriesList/SaveMenu/SaveMenu.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { ExportAnnotationsAsJsonMenuItem } from "./ExportAnnotationsAsJsonMenuItem";
 import { SaveProjectFileMenuItem } from "./SaveProjectFileMenuItem";
 import { ExportAnnotationsAsImagesMenuItem } from "./ExportAnnotationsAsImagesMenuItem";
+import { ExportAnnotationsAsMatrixMenuItem } from "./ExportAnnotationsAsMatrixMenuItem";
 
 type SaveMenuProps = {
   popupState: any;
@@ -15,6 +16,7 @@ export const SaveMenu = ({ popupState }: SaveMenuProps) => {
     <Menu {...bindMenu(popupState)}>
       {/*<ExportAnnotationsAsJsonMenuItem popupState={popupState} />*/}
       <ExportAnnotationsAsImagesMenuItem popupState={popupState} />
+      <ExportAnnotationsAsMatrixMenuItem popupState={popupState} />
       <SaveProjectFileMenuItem popupState={popupState} />
     </Menu>
   );


### PR DESCRIPTION
Resolves #258

I've put together the basic functionality for this. The function generates images per-category with each object assigned a unique number on the output array. Some oddities to note:

- JS seems to lack a native .tiff encoder, so we're still saving as .png for now. This means that everything is in RGB, though I've still made it greyscale by duplicating the channels.
- Labels start at [1, 1, 1, 255], meaning that most image viewers will make the image look blank. This is somewhat expected, just play with the contrast to check that labels exist. Shameless plug for ImQuick.
- Label IDs are assigned in the order that the annotations were created, rather than from top-left to bottom-right. Not much we can do about this without making a system for sorting annotations by position. Do we care?
- Overlapping objects are not supported, the higher ID will take priority and overwrite overlapped regions.


Folder structure is `image/category.png`, with one image per annotation category. I think this makes the most sense.